### PR TITLE
Restrict requests for python 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests>=2.7.0
+requests

--- a/requirements27-32.txt
+++ b/requirements27-32.txt
@@ -1,0 +1,2 @@
+requests<=2.10.0
+configparser==3.5.0

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -1,2 +1,0 @@
-requests>=2.7.0
-configparser

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ from setuptools import setup, find_packages
 import sys
 import pushoverflow
 
-if sys.version_info[0] == 2:
-    requirements = "requirements27.txt"
+ver = sys.version_info
+if ver[0] == 2 or (ver[0] == 3 and ver[1] == 2):
+    requirements = "requirements27-32.txt"
 else:
     requirements = "requirements.txt"
 


### PR DESCRIPTION
requests has dropped support for python3.2, and is failing in latest
releases. Restricting the version for 3.2.
