### PR TITLE
Refactor code from cli

### DIFF
--- a/pushoverflow.ini.sample
+++ b/pushoverflow.ini.sample
@@ -1,5 +1,5 @@
 [Global]
-time_delta_minutes = 60
+check_minutes_back = 60
 
 [Pushover]
 appkey = <your appkey>
@@ -7,7 +7,7 @@ userkey = <your userkey>
 #Priority 0 is normal. -1 will not trigger sound or vibration. 1 will bypass quiet hours.
 priority = 0
 #device name if you want notifications to go to a specific device
-#device = 
+#device =
 
 [stackoverflow]
 #show me new python questions on stackoverflow, but nothing python-2.7

--- a/pushoverflow/cli.py
+++ b/pushoverflow/cli.py
@@ -1,119 +1,15 @@
-import click
-import calendar
 import configparser
-import datetime
-import html
 import logging
 import os
 
-import requests
+import click
+
+from pushoverflow.core import Notifier
 
 with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
     VERSION = f.readlines()[0].strip()
 
-STACK_EXCHANGE_BASE_URL = "http://api.stackexchange.com/2.1"
-PUSHOVER_BASE_URL = "https://api.pushover.net/1/messages.json"
 log = logging.getLogger(__name__)
-
-
-def send_to_pushover(pushover_config, title, message, url=None,
-                     url_title=None):
-    '''Send notification to Pushover'''
-    payload = {"title": title, "message": message}
-    payload["token"] = pushover_config.get("appkey")
-    payload["user"] = pushover_config.get("userkey")
-    payload["priority"] = pushover_config.get("priority")
-    if "device" in pushover_config:
-        payload["device"] = pushover_config.get("device")
-    if url:
-        payload["url"] = url
-        payload["url_title"] = url_title
-
-    res = requests.post(PUSHOVER_BASE_URL, data=payload)
-    if res.status_code == requests.codes.ok:
-        log.debug("Sent to Pushover: %s", payload)
-        return True
-    else:
-        log.warning("Failed to send to Pushover: %s", res.text)
-        return False
-
-
-def send_questions_to_pushover(pushover_config, exchange_name, questions):
-    '''Send notification of new StackExchange questions to Pushover.
-       Title will contain the exchange name and message will contain
-       either the number of new questions or the title of the question
-       if only one exists.
-    '''
-    title = "PushOverflow: " + exchange_name
-    if len(questions) == 1:
-        message = ("New question posted: " + html.unescape(
-            questions[0].get("title")))
-        url = questions[0].get("link")
-        url_title = "Open question"
-    else:
-        message = str(len(questions)) + " new questions posted"
-        url = ("http://" + exchange_name
-               + ".stackexchange.com/questions?sort=newest")
-        url_title = "Open " + exchange_name + ".stackexchange.com"
-    return send_to_pushover(pushover_config, title, message, url, url_title)
-
-
-def get_stack_exchange_questions(stack_exchange_site, from_date):
-    '''Get new questions posted to stackexchange site since the
-       provided time.
-    '''
-    stack_url = STACK_EXCHANGE_BASE_URL + "/questions"
-    payload = {"fromdate": calendar.timegm(from_date.utctimetuple()),
-               "site": stack_exchange_site}
-    res = requests.get(stack_url, params=payload)
-    if res.status_code != requests.codes.ok:
-        log.warning("Failed to retrieve from StackExchange: %s", res.text)
-        return {}
-    return res.json()
-
-
-def filter_questions(questions, tags, excluded):
-    '''Takes a list of questions and filters them.
-       If tags is not empty, will filter any questions that do not
-       include one of these tags.
-       If excluded is not empty, will filter any questions that include
-       one of these tags.
-    '''
-    filtered_questions = []
-    for question in questions.get("items"):
-        question_tags = question.get("tags")
-        in_tags = False
-        in_excluded = False
-        for tag in question_tags:
-            if len(tags) == 0 or tag in tags:
-                in_tags = True
-            if tag in excluded:
-                in_excluded = True
-        if in_tags and not in_excluded:
-            filtered_questions.append(question)
-            log.debug("Found question: '%s'", question.get("title"))
-        log.debug("Filtered question: '%s', with tags: %s",
-                  question.get("title"), question_tags)
-
-    return filtered_questions
-
-
-def check_exchange(exchange, from_date):
-    '''Get new questions for this stackexchange site based off of
-       filters provided in configuration file.
-    '''
-    tags = excluded = []
-    if exchange.get("tags"):
-        tags = [x.strip() for x in exchange.get("tags").split(",")]
-    if exchange.get("exclude"):
-        excluded = [x.strip() for x in exchange.get("exclude").split(",")]
-    log.info("check_exchange: [%s], from_date: %s",
-             exchange.name, from_date.isoformat())
-
-    questions = get_stack_exchange_questions(exchange.name, from_date)
-    if questions:
-        questions = filter_questions(questions, tags, excluded)
-    return questions
 
 
 def configure_logging(verbose: bool):
@@ -123,16 +19,17 @@ def configure_logging(verbose: bool):
         logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
-def get_check_time(time_delta_minutes):
-    '''Here mostly for test mocking'''
-    return datetime.datetime.utcnow() - datetime.timedelta(
-        minutes=time_delta_minutes)
-
-
 def get_configuration(config_file: str):
     config = configparser.ConfigParser()
     config.read(config_file)
     return config
+
+
+def validate_config(config):
+    config.get("Global", "check_minutes_back")
+    config.get("Pushover", "appkey")
+    config.get("Pushover", "userkey")
+    config.get("Pushover", "priority")
 
 
 @click.command()
@@ -144,21 +41,10 @@ def main(config: str, verbose: bool):
     """Check for new StackExchange questions and notify via Pushover"""
     configure_logging(verbose)
     config = get_configuration(config)
-    from_date = None
+
     try:
-        time_delta = int(config.get("Global", "time_delta_minutes"))
-        from_date = get_check_time(time_delta)
-        config.get("Pushover", "appkey")
-        config.get("Pushover", "userkey")
+        validate_config(config)
+        notifier = Notifier(config)
+        notifier.process()
     except (configparser.NoSectionError, configparser.NoOptionError) as err:
         print("Missing properties in configuration file:", err)
-        return
-
-    for section in config.sections():
-        if section == "Global" or section == "Pushover":
-            continue
-        exchange = config[section]
-        questions = check_exchange(exchange, from_date)
-        if len(questions) > 0:
-            send_questions_to_pushover(
-                config["Pushover"], exchange.name, questions)

--- a/pushoverflow/core.py
+++ b/pushoverflow/core.py
@@ -1,0 +1,70 @@
+import html
+import logging
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from pushoverflow.stack_exchange import check_exchange
+
+PUSHOVER_BASE_URL = "https://api.pushover.net/1/messages.json"
+log = logging.getLogger(__name__)
+
+
+class Notifier:
+
+    def __init__(self, config):
+        self.config = config
+
+    def get_check_time(self, check_minutes_back):
+        """Here mostly for test mocking"""
+        return datetime.now(timezone.utc) - timedelta(minutes=check_minutes_back)
+
+    def send_to_pushover(self, title: str, message: str, url: str, url_title: str):
+        """Send notification to Pushover"""
+        pushover_config = self.config["Pushover"]
+        payload = {
+            "title": title,
+            "message": message,
+            "token": pushover_config.get("appkey"),
+            "user": pushover_config.get("userkey"),
+            "priority": pushover_config.get("priority"),
+            "url": url,
+            "url_title": url_title
+        }
+        if "device" in pushover_config:
+            payload["device"] = pushover_config.get("device")
+
+        res = requests.post(PUSHOVER_BASE_URL, data=payload)
+        if res.status_code == requests.codes.ok:
+            log.debug("Sent to Pushover: %s", payload)
+            return True
+        else:
+            log.warning("Failed to send to Pushover: %s", res.text)
+            return False
+
+    def handle_questions(self, exchange_name, questions):
+        """Handle questions from a StackExchange. Send notification of questions to Pushover.
+        Title will contain the exchange name and message will contain either the number of new
+        questions or the title of the question if only one exists.
+        """
+        if len(questions) == 1:
+            title = html.unescape(questions[0].get("title"))
+            message = f"New question posted: {title}"
+            url = questions[0].get("link")
+            url_title = "Open question"
+        else:
+            message = f"{len(questions)} new questions posted"
+            url = f"http://{exchange_name}.stackexchange.com/questions?sort=newest"
+            url_title = f"Open {exchange_name}.stackexchange.com"
+
+        return self.send_to_pushover(f"PushOverflow: {exchange_name}", message, url, url_title)
+
+    def process(self):
+        from_date = self.get_check_time(int(self.config.get("Global", "check_minutes_back")))
+        for section in self.config.sections():
+            if section == "Global" or section == "Pushover":
+                continue
+            exchange = self.config[section]
+            questions = check_exchange(exchange, from_date)
+            if len(questions) > 0:
+                self.handle_questions(exchange.name, questions)

--- a/pushoverflow/stack_exchange.py
+++ b/pushoverflow/stack_exchange.py
@@ -1,0 +1,62 @@
+import calendar
+import logging
+
+import requests
+
+STACK_EXCHANGE_BASE_URL = "http://api.stackexchange.com/2.1"
+
+log = logging.getLogger(__name__)
+
+
+def get_stack_exchange_questions(stack_exchange_site, from_date):
+    """Get new questions posted to stackexchange site since the provided time."""
+    stack_url = STACK_EXCHANGE_BASE_URL + "/questions"
+    payload = {
+        "fromdate": calendar.timegm(from_date.utctimetuple()),
+        "site": stack_exchange_site
+    }
+    res = requests.get(stack_url, params=payload)
+    if res.status_code != requests.codes.ok:
+        log.warning("Failed to retrieve from StackExchange: %s", res.text)
+        return {}
+    return res.json()
+
+
+def filter_questions(questions, tags, excluded):
+    """Takes a list of questions and filters them.
+
+    If tags is not empty, will filter any questions that do not include one of these tags.
+    If excluded is not empty, will filter any questions that include one of these tags.
+    """
+    filtered_questions = []
+    for question in questions.get("items"):
+        question_tags = question.get("tags")
+        in_tags = False
+        in_excluded = False
+        for tag in question_tags:
+            if len(tags) == 0 or tag in tags:
+                in_tags = True
+            if tag in excluded:
+                in_excluded = True
+        if in_tags and not in_excluded:
+            filtered_questions.append(question)
+            log.debug("Found question: '%s'", question.get("title"))
+        log.debug("Filtered question: '%s', with tags: %s", question.get("title"), question_tags)
+    return filtered_questions
+
+
+def check_exchange(exchange, from_date):
+    """Get new questions for this stackexchange site based off of filters provided
+    in configuration file.
+    """
+    tags = excluded = []
+    if exchange.get("tags"):
+        tags = [x.strip() for x in exchange.get("tags").split(",")]
+    if exchange.get("exclude"):
+        excluded = [x.strip() for x in exchange.get("exclude").split(",")]
+    log.info("check_exchange: [%s], from_date: %s", exchange.name, from_date.isoformat())
+
+    questions = get_stack_exchange_questions(exchange.name, from_date)
+    if questions:
+        questions = filter_questions(questions, tags, excluded)
+    return questions

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import pushoverflow
 
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 import configparser
-import datetime
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
+
 from click.testing import CliRunner
+
 from pushoverflow import cli
 
 
@@ -23,101 +24,33 @@ class CliTests(unittest.TestCase):
 
         logging.basicConfig.assert_called_with(format='%(asctime)s - %(levelname)s: %(message)s', level=logging.DEBUG)
 
-    @patch("pushoverflow.cli.check_exchange")
+    @patch("pushoverflow.core.check_exchange")
     @patch("pushoverflow.cli.get_configuration")
-    def test_main_no_config(self, mock_config, check):
+    def test_main_no_config(self, mock_config, mock_check_exchange):
         conf = configparser.ConfigParser()
         mock_config.return_value = conf
 
+        # Missing Global config section
         runner = CliRunner()
         result = runner.invoke(cli.main)
-        # Missing Global config section
         self.assertTrue(mock_config.called)
-        self.assertFalse(check.called)
-        self.assertTrue("Missing properties in configuration file: No section:" in result.output)
-        self.assertTrue("'Global'" in result.output)
+        self.assertFalse(mock_check_exchange.called)
+        self.assertTrue("Missing properties in configuration file: No section: 'Global'" in result.output)
 
         # Missing Pushover config section
         conf.read_dict({
-            "Global": {"time_delta_minutes": 60}
+            "Global": {"check_minutes_back": 60}
         })
+        mock_config.return_value = conf
         result = runner.invoke(cli.main)
-        self.assertTrue("Missing properties in configuration file: No section:" in result.output)
-        self.assertTrue("'Pushover'" in result.output)
+        self.assertTrue("Missing properties in configuration file: No section: 'Pushover'" in result.output)
 
         # Missing Pushover option
         conf.read_dict({
             "Pushover": {"foo": "bar"}
         })
+        mock_config.return_value = conf
         result = runner.invoke(cli.main)
-        self.assertTrue("Missing properties in configuration file: No option" in result.output)
-        self.assertTrue("'appkey'" in result.output)
-        self.assertTrue("'Pushover'" in result.output)
-
-    @patch("pushoverflow.cli.check_exchange")
-    @patch("pushoverflow.cli.get_configuration")
-    def test_main_no_exchanges(self, mock_config, check):
-        conf = configparser.ConfigParser()
-        conf.read_dict({
-            "Global": {"time_delta_minutes": 60}
-        })
-        mock_config.return_value = conf
-
-        runner = CliRunner()
-        runner.invoke(cli.main)
-
-        self.assertTrue(mock_config.called)
-        self.assertFalse(check.called)
-
-    @patch("pushoverflow.cli.send_questions_to_pushover")
-    @patch("pushoverflow.cli.check_exchange")
-    @patch("pushoverflow.cli.get_check_time")
-    @patch("pushoverflow.cli.get_configuration")
-    def test_main_with_exchanges(self, mock_config, now, check, pushover):
-        now.return_value = datetime.datetime.now()
-        conf = configparser.ConfigParser()
-        conf.read_dict({
-            "Global": {"time_delta_minutes": 60},
-            "Pushover": {"appkey": "some_key", "userkey": "some_key"},
-            "stackoverflow": {"tags": "python"}
-        })
-        mock_config.return_value = conf
-
-        runner = CliRunner()
-        runner.invoke(cli.main)
-
-        self.assertTrue(mock_config.called)
-        check.assert_called_once_with(conf["stackoverflow"], now())
-        self.assertFalse(pushover.called)
-
-    @patch("pushoverflow.cli.send_questions_to_pushover")
-    @patch("pushoverflow.cli.check_exchange")
-    @patch("pushoverflow.cli.get_check_time")
-    @patch("pushoverflow.cli.get_configuration")
-    def test_main_with_exchange_questions(self, mock_config, now, check,
-                                          pushover):
-        now.return_value = datetime.datetime.now()
-        conf = configparser.ConfigParser()
-        conf.read_dict({
-            "Global": {"time_delta_minutes": 60},
-            "Pushover": {"appkey": "some_key", "userkey": "some_key"},
-            "stackoverflow": {"tags": "python"},
-            "scifi": {"tags": "star-trek"}
-        })
-        mock_config.return_value = conf
-        check.return_value = ["test"]
-
-        runner = CliRunner()
-        runner.invoke(cli.main)
-
-        self.assertTrue(mock_config.called)
-        check.assert_has_calls([
-            call(conf["stackoverflow"], now()),
-            call(conf["scifi"], now())
-        ], any_order=True)
-
-        self.assertTrue(pushover.called)
-        pushover.assert_has_calls([
-            call(conf["Pushover"], "stackoverflow", ["test"]),
-            call(conf["Pushover"], "scifi", ["test"])
-        ], any_order=True)
+        self.assertTrue(
+            "Missing properties in configuration file: No option 'appkey' in section: 'Pushover'" in result.output
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,67 @@
+import configparser
+import datetime
+import unittest
+from unittest.mock import call, patch
+
+from pushoverflow.core import Notifier
+
+
+class CoreTests(unittest.TestCase):
+
+    @patch("pushoverflow.core.check_exchange")
+    def test_main_no_exchanges(self, mock_handle):
+        conf = configparser.ConfigParser()
+        conf.read_dict({
+            "Global": {"check_minutes_back": 60}
+        })
+
+        notifier = Notifier(conf)
+        notifier.process()
+
+        self.assertFalse(mock_handle.called)
+
+    @patch.object(Notifier, "handle_questions")
+    @patch("pushoverflow.core.check_exchange")
+    @patch.object(Notifier, "get_check_time")
+    def test_main_with_exchange(self, mock_check_time, mock_check_exchange, mock_handle):
+        mock_check_time.return_value = datetime.datetime.now()
+        conf = configparser.ConfigParser()
+        conf.read_dict({
+            "Global": {"check_minutes_back": 60},
+            "Pushover": {"appkey": "some_key", "userkey": "some_key"},
+            "stackoverflow": {"tags": "python"}
+        })
+
+        notifier = Notifier(conf)
+        notifier.process()
+
+        mock_check_exchange.assert_called_once_with(conf["stackoverflow"], mock_check_time())
+        self.assertFalse(mock_handle.called)
+
+    @patch.object(Notifier, "handle_questions")
+    @patch("pushoverflow.core.check_exchange")
+    @patch.object(Notifier, "get_check_time")
+    def test_main_with_exchanges(self, mock_check_time, mock_check_exchange, mock_handle):
+        mock_check_time.return_value = datetime.datetime.now()
+        conf = configparser.ConfigParser()
+        conf.read_dict({
+            "Global": {"check_minutes_back": 60},
+            "Pushover": {"appkey": "some_key", "userkey": "some_key"},
+            "stackoverflow": {"tags": "python"},
+            "scifi": {"tags": "star-trek"}
+        })
+        mock_check_exchange.return_value = ["test"]
+
+        notifier = Notifier(conf)
+        notifier.process()
+
+        mock_check_exchange.assert_has_calls([
+            call(conf["stackoverflow"], mock_check_time()),
+            call(conf["scifi"], mock_check_time())
+        ], any_order=True)
+
+        self.assertTrue(mock_handle.called)
+        mock_handle.assert_has_calls([
+            call("stackoverflow", ["test"]),
+            call("scifi", ["test"])
+        ], any_order=True)

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -4,13 +4,14 @@ import unittest
 from unittest.mock import patch
 
 import httpretty
-from pushoverflow import cli
+
+from pushoverflow.stack_exchange import check_exchange, get_stack_exchange_questions
 
 
 class StackExchangeTests(unittest.TestCase):
 
-    @patch("pushoverflow.cli.filter_questions")
-    @patch("pushoverflow.cli.get_stack_exchange_questions")
+    @patch("pushoverflow.stack_exchange.filter_questions")
+    @patch("pushoverflow.stack_exchange.get_stack_exchange_questions")
     def test_check_exchange(self, get_questions, filter_questions):
         conf = configparser.ConfigParser()
         conf.read_dict({
@@ -22,7 +23,7 @@ class StackExchangeTests(unittest.TestCase):
         now = datetime.datetime.now()
         get_questions.return_value = ["test"]
 
-        cli.check_exchange(conf["stackoverflow"], now)
+        check_exchange(conf["stackoverflow"], now)
 
         get_questions.assert_called_once_with("stackoverflow", now)
         filter_questions.assert_called_once_with(
@@ -30,8 +31,8 @@ class StackExchangeTests(unittest.TestCase):
             ["python", "java"],
             ["logging", "stuff"])
 
-    @patch("pushoverflow.cli.filter_questions")
-    @patch("pushoverflow.cli.get_stack_exchange_questions")
+    @patch("pushoverflow.stack_exchange.filter_questions")
+    @patch("pushoverflow.stack_exchange.get_stack_exchange_questions")
     def test_check_exchange_no_params(self, get_questions, filter_questions):
         conf = configparser.ConfigParser()
         conf.read_dict({
@@ -40,7 +41,7 @@ class StackExchangeTests(unittest.TestCase):
         now = datetime.datetime.now()
         get_questions.return_value = None
 
-        cli.check_exchange(conf["stackoverflow"], now)
+        check_exchange(conf["stackoverflow"], now)
 
         get_questions.assert_called_once_with("stackoverflow", now)
         self.assertFalse(filter_questions.called)
@@ -57,7 +58,7 @@ class StackExchangeTests(unittest.TestCase):
         }
         from_time = datetime.datetime(2015, 8, 25, 15, 26, 0, 0)
 
-        result = cli.get_stack_exchange_questions("stackoverflow", from_time)
+        result = get_stack_exchange_questions("stackoverflow", from_time)
 
         self.assertEqual(result, [{"foo": "bar"}])
         self.assertEqual(httpretty.last_request().method, "GET")
@@ -71,7 +72,6 @@ class StackExchangeTests(unittest.TestCase):
             status=401
         )
 
-        result = cli.get_stack_exchange_questions("stackoverflow",
-                                                  datetime.datetime.now())
+        result = get_stack_exchange_questions("stackoverflow", datetime.datetime.now())
 
         self.assertEqual(result, {})


### PR DESCRIPTION
Moving the core functionality out of the cli module to clean up and to stop passing config all the way down.

Tests split along new lines.